### PR TITLE
added eth closing price

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,7 +26,8 @@ from technical_indicators import (
     bitcoin_ema,
     macd,
     rsi,
-    bollinger_bands
+    bollinger_bands,
+    ethereum_closing_prices
     )
 
 def main() -> None:
@@ -40,7 +41,8 @@ def main() -> None:
         bitcoin_ema,
         macd,
         rsi,
-        bollinger_bands
+        bollinger_bands,
+        ethereum_closing_prices
     ]
 
     for job in jobs:

--- a/technical_indicators/ethereum_closing_prices.py
+++ b/technical_indicators/ethereum_closing_prices.py
@@ -1,0 +1,93 @@
+import pandas as pd
+import requests
+import pandas_gbq
+from google.cloud import bigquery
+from typing import Any
+import os
+import logging
+from google.oauth2 import service_account
+
+destination_table = "ethereum_price"
+
+logger = logging.getLogger(__name__)
+
+def fetch_eth_price() -> pd.DataFrame:
+    url = 'https://api.coingecko.com/api/v3/coins/ethereum/market_chart'
+    params = {
+        'vs_currency': 'usd',
+        'days': '365',
+        'interval': 'daily'
+    }
+    response = requests.get(url, params=params)
+    response.raise_for_status()
+    data = response.json()
+
+    # Extract prices, market caps, and total volumes
+    prices = data['prices']
+    market_caps = data['market_caps']
+    total_volumes = data['total_volumes']
+
+    # Create DataFrames for each metric
+    df_prices = pd.DataFrame(prices, columns=['timestamp', 'price'])
+    df_market_caps = pd.DataFrame(market_caps, columns=['timestamp', 'market_cap'])
+    df_volumes = pd.DataFrame(total_volumes, columns=['timestamp', 'total_volume'])
+
+    # Merge all data on timestamp
+    df = df_prices.merge(df_market_caps, on='timestamp').merge(df_volumes, on='timestamp')
+
+    # Parse timestamps in UTC, normalize to midnight, then shift back one day
+    ts_utc = pd.to_datetime(df['timestamp'], unit='ms', utc=True)
+    dates_utc = ts_utc.dt.normalize() - pd.Timedelta(days=1)
+
+    # Use the shifted date as the label for the "closing" day
+    df['date'] = dates_utc.dt.date
+    df = df.drop(columns=['timestamp']).sort_values('date').reset_index(drop=True)
+
+    # Ensure one row per date (in case of any duplicates)
+    df = df.groupby('date', as_index=False).last()
+    df = df.rename(columns={'date': 'timestamp'})
+
+    logger.info(f"imported {len(df)} rows of data from {url}")
+
+    return df
+
+
+def schema() -> list[dict]:
+    """
+    create the schema for the bq table
+    """
+    table_schema = [
+        {'name': 'timestamp', 'type': 'DATE', 'description': 'The date of the price'},
+        {'name': 'price', 'type': 'FLOAT64', 'description': 'closing price'},
+        {'name': 'market_cap', 'type': 'FLOAT64', 'description': 'market cap for the daily timeframe'},
+        {'name': 'total_volume', 'type': 'FLOAT64', 'description': 'total volume of transactions happened daily'}
+    ]
+    return table_schema
+
+
+def run_etl(credentials,dataset:str) -> None:
+    project = "connection-123"
+    client = bigquery.Client(credentials=credentials, project=project)
+    table = fetch_eth_price()
+    table_schema = schema()
+
+    job_config = bigquery.LoadJobConfig(
+        schema=table_schema,
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+        time_partitioning=bigquery.TimePartitioning(
+            type_=bigquery.TimePartitioningType.DAY,
+            field="timestamp"
+        ),
+        destination_table_description="Daily closing prices for ethereum"
+    )
+
+    table_ref = dataset + destination_table
+
+    job = client.load_table_from_dataframe(
+        table,
+        table_ref,
+        job_config=job_config
+    )
+
+    job.result()
+


### PR DESCRIPTION
This pull request adds support for importing Ethereum daily closing price data alongside existing technical indicators. The main change is the introduction of a new ETL job that fetches Ethereum price, market cap, and volume data from the CoinGecko API and loads it into BigQuery. The changes also update the job orchestration in `main.py` to include this new job.

**New ETL job for Ethereum price data:**

* Added a new module `technical_indicators/ethereum_closing_prices.py` that defines functions to fetch Ethereum daily closing prices from CoinGecko, transform the data, and load it into a BigQuery table with appropriate schema and partitioning.

**Integration with job orchestration:**

* Updated the import statement in `main.py` to include `ethereum_closing_prices`.
* Added `ethereum_closing_prices` to the list of ETL jobs executed in the `main()` function in `main.py`.