### PR TITLE
added mvrv score

### DIFF
--- a/logfile.txt
+++ b/logfile.txt
@@ -838,3 +838,59 @@
 2025-09-17 09:28:10,286 - __main__ - INFO - Query processed 78,072 bytes (0.07 MB)
 2025-09-17 09:28:10,286 - __main__ - INFO - Fetched 180 rows of combined indicator data
 2025-09-17 09:28:10,287 - __main__ - INFO - Technical analysis report generated and saved to 'report analysis.txt'
+2025-09-17 15:30:49,616 - __main__ - INFO - Starting ETL job: Technical_Indicators.Bitcoin_Transactions_Volume
+2025-09-17 15:30:53,810 - technical_indicators.bitcoin_transactions_volume - INFO - Query processed 379,368 bytes (0.36 MB)
+2025-09-17 15:30:57,384 - pandas_gbq.gbq_connector - INFO - 109 out of 109 rows loaded.
+2025-09-17 15:30:57,384 - __main__ - INFO - Starting ETL job: Technical_Indicators.Bitcoin_Closing_Prices
+2025-09-17 15:30:57,662 - technical_indicators.bitcoin_closing_prices - INFO - imported 365 rows of data from https://api.coingecko.com/api/v3/coins/bitcoin/market_chart
+2025-09-17 15:31:05,732 - pandas_gbq.gbq_connector - INFO - 365 out of 365 rows loaded.
+2025-09-17 15:31:05,732 - __main__ - INFO - Starting ETL job: Technical_Indicators.Btc_Moving_Averages
+2025-09-17 15:31:10,515 - technical_indicators.btc_moving_averages - INFO - Query processed 5,840 bytes (0.01 MB)
+2025-09-17 15:31:14,283 - pandas_gbq.gbq_connector - INFO - 365 out of 365 rows loaded.
+2025-09-17 15:31:14,283 - __main__ - INFO - Starting ETL job: Technical_Indicators.Bitcoin_Ema
+2025-09-17 15:31:16,696 - technical_indicators.bitcoin_ema - INFO - Query processed 5,840 bytes (0.01 MB)
+2025-09-17 15:31:21,070 - pandas_gbq.gbq_connector - INFO - 365 out of 365 rows loaded.
+2025-09-17 15:31:21,070 - __main__ - INFO - Starting ETL job: Technical_Indicators.Macd
+2025-09-17 15:31:23,746 - technical_indicators.macd - INFO - Query processed 11,680 bytes (0.01 MB)
+2025-09-17 15:31:26,723 - pandas_gbq.gbq_connector - INFO - 365 out of 365 rows loaded.
+2025-09-17 15:31:26,723 - __main__ - INFO - Starting ETL job: Technical_Indicators.Rsi
+2025-09-17 15:31:29,197 - technical_indicators.rsi - INFO - Query processed 5,840 bytes (0.01 MB)
+2025-09-17 15:31:33,203 - pandas_gbq.gbq_connector - INFO - 365 out of 365 rows loaded.
+2025-09-17 15:31:33,203 - __main__ - INFO - Starting ETL job: Technical_Indicators.Bollinger_Bands
+2025-09-17 15:31:35,554 - technical_indicators.bollinger_bands - INFO - Query processed 5,840 bytes (0.01 MB)
+2025-09-17 15:31:40,520 - pandas_gbq.gbq_connector - INFO - 365 out of 365 rows loaded.
+2025-09-17 15:31:40,520 - __main__ - INFO - Starting ETL job: Technical_Indicators.Ethereum_Closing_Prices
+2025-09-17 15:31:40,785 - technical_indicators.ethereum_closing_prices - INFO - imported 365 rows of data from https://api.coingecko.com/api/v3/coins/ethereum/market_chart
+2025-09-17 15:31:49,613 - __main__ - INFO - Starting ETL job: Technical_Indicators.Tether_Data
+2025-09-17 15:31:49,865 - technical_indicators.tether_data - INFO - imported 365 rows of data from https://api.coingecko.com/api/v3/coins/tether/market_chart
+2025-09-17 15:32:01,275 - __main__ - INFO - Starting ETL job: Technical_Indicators.Cmc_Data
+2025-09-17 15:32:04,649 - __main__ - INFO - Starting ETL job: Technical_Indicators.Mvrv_Score
+2025-09-17 15:32:04,817 - technical_indicators.mvrv_score - INFO - imported 100 rows of data from https://community-api.coinmetrics.io/v4/timeseries/asset-metrics
+2025-09-17 15:33:07,378 - __main__ - INFO - Starting ETL job: Technical_Indicators.Bitcoin_Transactions_Volume
+2025-09-17 15:33:11,045 - technical_indicators.bitcoin_transactions_volume - INFO - Query processed 379,368 bytes (0.36 MB)
+2025-09-17 15:33:15,127 - pandas_gbq.gbq_connector - INFO - 109 out of 109 rows loaded.
+2025-09-17 15:33:15,127 - __main__ - INFO - Starting ETL job: Technical_Indicators.Bitcoin_Closing_Prices
+2025-09-17 15:33:15,358 - technical_indicators.bitcoin_closing_prices - INFO - imported 365 rows of data from https://api.coingecko.com/api/v3/coins/bitcoin/market_chart
+2025-09-17 15:33:18,333 - pandas_gbq.gbq_connector - INFO - 365 out of 365 rows loaded.
+2025-09-17 15:33:18,333 - __main__ - INFO - Starting ETL job: Technical_Indicators.Btc_Moving_Averages
+2025-09-17 15:33:23,281 - technical_indicators.btc_moving_averages - INFO - Query processed 5,840 bytes (0.01 MB)
+2025-09-17 15:33:26,641 - pandas_gbq.gbq_connector - INFO - 365 out of 365 rows loaded.
+2025-09-17 15:33:26,641 - __main__ - INFO - Starting ETL job: Technical_Indicators.Bitcoin_Ema
+2025-09-17 15:33:28,928 - technical_indicators.bitcoin_ema - INFO - Query processed 5,840 bytes (0.01 MB)
+2025-09-17 15:33:31,997 - pandas_gbq.gbq_connector - INFO - 365 out of 365 rows loaded.
+2025-09-17 15:33:31,997 - __main__ - INFO - Starting ETL job: Technical_Indicators.Macd
+2025-09-17 15:33:34,351 - technical_indicators.macd - INFO - Query processed 11,680 bytes (0.01 MB)
+2025-09-17 15:33:37,770 - pandas_gbq.gbq_connector - INFO - 365 out of 365 rows loaded.
+2025-09-17 15:33:37,770 - __main__ - INFO - Starting ETL job: Technical_Indicators.Rsi
+2025-09-17 15:33:40,260 - technical_indicators.rsi - INFO - Query processed 5,840 bytes (0.01 MB)
+2025-09-17 15:33:42,975 - pandas_gbq.gbq_connector - INFO - 365 out of 365 rows loaded.
+2025-09-17 15:33:42,975 - __main__ - INFO - Starting ETL job: Technical_Indicators.Bollinger_Bands
+2025-09-17 15:33:45,354 - technical_indicators.bollinger_bands - INFO - Query processed 5,840 bytes (0.01 MB)
+2025-09-17 15:33:50,634 - pandas_gbq.gbq_connector - INFO - 365 out of 365 rows loaded.
+2025-09-17 15:33:50,634 - __main__ - INFO - Starting ETL job: Technical_Indicators.Ethereum_Closing_Prices
+2025-09-17 15:33:50,874 - technical_indicators.ethereum_closing_prices - INFO - imported 365 rows of data from https://api.coingecko.com/api/v3/coins/ethereum/market_chart
+2025-09-17 15:34:00,370 - __main__ - INFO - Starting ETL job: Technical_Indicators.Tether_Data
+2025-09-17 15:34:00,636 - technical_indicators.tether_data - INFO - imported 365 rows of data from https://api.coingecko.com/api/v3/coins/tether/market_chart
+2025-09-17 15:34:07,633 - __main__ - INFO - Starting ETL job: Technical_Indicators.Cmc_Data
+2025-09-17 15:34:12,155 - __main__ - INFO - Starting ETL job: Technical_Indicators.Mvrv_Score
+2025-09-17 15:34:12,358 - technical_indicators.mvrv_score - INFO - imported 100 rows of data from https://community-api.coinmetrics.io/v4/timeseries/asset-metrics

--- a/main.py
+++ b/main.py
@@ -29,7 +29,8 @@ from technical_indicators import (
     bollinger_bands,
     ethereum_closing_prices,
     tether_data,
-    cmc_data
+    cmc_data,
+    mvrv_score
     )
 
 def main() -> None:
@@ -46,7 +47,8 @@ def main() -> None:
         bollinger_bands,
         ethereum_closing_prices,
         tether_data,
-        cmc_data
+        cmc_data,
+        mvrv_score
     ]
 
     for job in jobs:

--- a/technical_indicators/ethereum_closing_prices.py
+++ b/technical_indicators/ethereum_closing_prices.py
@@ -64,7 +64,6 @@ def schema() -> list[dict]:
     ]
     return table_schema
 
-
 def run_etl(credentials,dataset:str) -> None:
     project = "connection-123"
     client = bigquery.Client(credentials=credentials, project=project)

--- a/technical_indicators/mvrv_score.py
+++ b/technical_indicators/mvrv_score.py
@@ -1,0 +1,79 @@
+
+import pandas as pd
+import requests
+import pandas_gbq
+from google.cloud import bigquery
+from typing import Any
+import os
+import logging
+from google.oauth2 import service_account
+from datetime import datetime
+
+destination_table = "mvrv_score"
+
+logger = logging.getLogger(__name__)
+
+def fetch_mvrv() -> pd.DataFrame:
+    url = "https://community-api.coinmetrics.io/v4/timeseries/asset-metrics"
+
+    params = {
+        'assets': 'btc',
+        'metrics': 'CapMVRVCur',
+        'start_time': '2020-01-01',
+        'end_time': datetime.now().strftime('%Y-%m-%d'),
+        'frequency': '1d'
+    }
+    response = requests.get(url, params=params)
+    response.raise_for_status()
+    data = response.json()
+
+    df = pd.DataFrame([
+        {
+            'time': point['time'],
+            'mvrv': float(point['CapMVRVCur'])
+        }
+        for point in data['data']
+    ])
+
+    df['time'] = pd.to_datetime(df['time']).dt.date
+
+    logger.info(f"imported {len(df)} rows of data from {url}")
+
+    return df
+
+def schema() -> list[dict]:
+    """
+    create the schema for the bq table
+    """
+    table_schema = [
+        {'name': 'time', 'type': 'DATE', 'description': 'The date of measurement'},
+        {'name': 'mvrv', 'type': 'FLOAT64', 'description': 'decimal value of the mvrv daily'},
+    ]
+
+    return table_schema
+
+def run_etl(credentials,dataset:str) -> None:
+    project = "connection-123"
+    client = bigquery.Client(credentials=credentials, project=project)
+    table = fetch_mvrv()
+    table_schema = schema()
+
+    job_config = bigquery.LoadJobConfig(
+        schema=table_schema,
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+        time_partitioning=bigquery.TimePartitioning(
+            type_=bigquery.TimePartitioningType.DAY,
+            field="time"
+        ),
+        destination_table_description="Daily value for the mvrv score"
+    )
+
+    table_ref = dataset + destination_table
+
+    job = client.load_table_from_dataframe(
+        table,
+        table_ref,
+        job_config=job_config
+    )
+
+    job.result()

--- a/testing_file.ipynb
+++ b/testing_file.ipynb
@@ -3,8 +3,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-16T14:49:11.375240Z",
-     "start_time": "2025-09-16T14:49:11.370904Z"
+     "end_time": "2025-09-17T13:21:41.357187Z",
+     "start_time": "2025-09-17T13:21:39.040577Z"
     }
    },
    "cell_type": "code",
@@ -19,13 +19,13 @@
    ],
    "id": "f2eb35a85ba5527b",
    "outputs": [],
-   "execution_count": 11
+   "execution_count": 1
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-16T14:49:11.823210Z",
-     "start_time": "2025-09-16T14:49:11.819999Z"
+     "end_time": "2025-09-17T13:21:42.164329Z",
+     "start_time": "2025-09-17T13:21:42.160649Z"
     }
    },
    "cell_type": "code",
@@ -37,13 +37,13 @@
    ],
    "id": "a8ecdc6ac17377bc",
    "outputs": [],
-   "execution_count": 12
+   "execution_count": 2
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-16T14:54:14.092126Z",
-     "start_time": "2025-09-16T14:54:14.086476Z"
+     "end_time": "2025-09-17T13:23:18.420740Z",
+     "start_time": "2025-09-17T13:23:18.415503Z"
     }
    },
    "cell_type": "code",
@@ -61,58 +61,48 @@
     "    response = requests.get(url, params=params)\n",
     "    response.raise_for_status()\n",
     "    data = response.json()\n",
-    "    df = pd.json_normalize(data, sep='_')\n",
     "\n",
-    "    return data\n"
+    "    df = pd.DataFrame([\n",
+    "        {\n",
+    "            'time': point['time'],\n",
+    "            'mvrv': float(point['CapMVRVCur'])\n",
+    "        }\n",
+    "        for point in data['data']\n",
+    "    ])\n",
+    "\n",
+    "    df['time'] = pd.to_datetime(df['time']).dt.date\n",
+    "\n",
+    "    return df\n"
    ],
    "id": "614938ee04e85973",
    "outputs": [],
-   "execution_count": 31
+   "execution_count": 10
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-16T14:54:14.606404Z",
-     "start_time": "2025-09-16T14:54:14.436359Z"
+     "end_time": "2025-09-17T13:23:19.331239Z",
+     "start_time": "2025-09-17T13:23:19.142974Z"
     }
    },
    "cell_type": "code",
    "source": "test = fetch_mvrv()",
    "id": "17b74d72d361bcac",
    "outputs": [],
-   "execution_count": 32
+   "execution_count": 11
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-16T15:03:19.318445Z",
-     "start_time": "2025-09-16T15:03:19.273215Z"
+     "end_time": "2025-09-17T13:24:41.565913Z",
+     "start_time": "2025-09-17T13:24:41.563350Z"
     }
    },
    "cell_type": "code",
-   "source": [
-    "df = pd.DataFrame(columns=['time', 'mvrv'])\n",
-    "\n",
-    "# Add rows one by one\n",
-    "for point in test['data']:\n",
-    "    new_row = pd.DataFrame({\n",
-    "        'time': [point['time']],\n",
-    "        'mvrv': [float(point['CapMVRVCur'])]\n",
-    "    })\n",
-    "    df = pd.concat([df, new_row], ignore_index=True)"
-   ],
+   "source": "",
    "id": "5770af575f92c663",
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\nrade\\AppData\\Local\\Temp\\ipykernel_15524\\362499577.py:9: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.\n",
-      "  df = pd.concat([df, new_row], ignore_index=True)\n"
-     ]
-    }
-   ],
-   "execution_count": 61
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {},


### PR DESCRIPTION
This pull request adds support for the MVRV Score technical indicator to the ETL pipeline. It introduces a new module for fetching and loading MVRV Score data into BigQuery, updates the job orchestration to include this new ETL job, and refines the notebook code to properly process and test the new data source.

**New ETL job for MVRV Score:**

* Added `technical_indicators/mvrv_score.py` which fetches daily MVRV Score data from the CoinMetrics API, processes it into a DataFrame, and loads it into BigQuery with an appropriate schema and partitioning.

**Pipeline and job orchestration updates:**

* Registered `mvrv_score` in the ETL job list in both the import statement and the job execution list in `main.py`, ensuring it runs as part of the main pipeline. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L32-R33) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L49-R51)

**Logging and monitoring improvements:**

* Updated `logfile.txt` to include detailed logs for the new MVRV Score ETL job, showing its execution and data import steps.

**Notebook and testing updates:**

* Modified `testing_file.ipynb` to update execution times, streamline the test code for fetching and processing MVRV Score data, and remove deprecated DataFrame concatenation logic for improved clarity and efficiency. [[1]](diffhunk://#diff-6428498655cd922b722c915cf79a1295f75d26b6189591e65bfcbde229f45c61L6-R7) [[2]](diffhunk://#diff-6428498655cd922b722c915cf79a1295f75d26b6189591e65bfcbde229f45c61L22-R28) [[3]](diffhunk://#diff-6428498655cd922b722c915cf79a1295f75d26b6189591e65bfcbde229f45c61L40-R46) [[4]](diffhunk://#diff-6428498655cd922b722c915cf79a1295f75d26b6189591e65bfcbde229f45c61L64-R105)

**Minor cleanup:**

* Removed an unnecessary blank line in `technical_indicators/ethereum_closing_prices.py` for code tidiness.