### PR TITLE
staging area

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import logging
 from google.oauth2 import service_account
 from typing import Any
 import time
+import os
 
 
 logging.basicConfig(
@@ -56,10 +57,18 @@ def validate_job_result(job_name: str, result: Any) -> bool:
     logger.debug(f"{job_name}: Validation passed - {result} bytes processed")
     return True
 
+def is_running_locally():
+    if os.getenv('COMPUTERNAME') is not None:
+        return 'local'
+    else:
+        return 'prod'
+
 def main() -> None:
     
     credentials = service_account.Credentials.from_service_account_file("connection-123-892e002c2def.json")
-    
+
+    mode = is_running_locally()
+
     jobs = [
         bitcoin_transactions_volume,
         bitcoin_closing_prices,
@@ -86,7 +95,7 @@ def main() -> None:
 
             start_time = time.time()
 
-            bytes_processed = job.run_etl(credentials, dataset)
+            bytes_processed = job.run_etl(credentials, dataset, mode)
 
             # Validate the result
             if validate_job_result(job_name, bytes_processed):

--- a/technical_indicators/bitcoin_closing_prices.py
+++ b/technical_indicators/bitcoin_closing_prices.py
@@ -63,19 +63,24 @@ def schema() -> list[dict]:
     ]
     return table_schema
 
-def run_etl(credentials,dataset:str) -> None:
-   
-    table = fetch_bitcoin_price()
-    table_schema = schema()
-    target_table = dataset + destination_table
+def run_etl(credentials,dataset:str,mode:str) -> None:
 
-    pandas_gbq.to_gbq(
-        dataframe=table,
-        destination_table=target_table,
-        project_id="connection-123",
-        table_schema=table_schema,
-        credentials=credentials,
-        if_exists="replace" 
-    )
+    if mode == 'prod':
 
-    return 0
+        table = fetch_bitcoin_price()
+        table_schema = schema()
+        target_table = dataset + destination_table
+
+        pandas_gbq.to_gbq(
+            dataframe=table,
+            destination_table=target_table,
+            project_id="connection-123",
+            table_schema=table_schema,
+            credentials=credentials,
+            if_exists="replace"
+        )
+
+        return 0
+
+    else:
+        print('no production mode')

--- a/technical_indicators/bitcoin_ema.py
+++ b/technical_indicators/bitcoin_ema.py
@@ -55,19 +55,24 @@ def schema() -> list[dict]:
     ]
     return table_schema
 
-def run_etl(credentials,dataset:str) -> None:
-   
-    table,bytes_processed = calculate_ema(credentials)
-    table_schema = schema()
-    target_table = dataset + destination_table
+def run_etl(credentials,dataset:str,mode:str) -> None:
 
-    pandas_gbq.to_gbq(
-        dataframe=table,
-        destination_table=target_table,
-        project_id="connection-123",
-        table_schema=table_schema,
-        credentials=credentials,
-        if_exists="replace" 
-    )
+    if mode == 'prod':
 
-    return bytes_processed
+        table,bytes_processed = calculate_ema(credentials)
+        table_schema = schema()
+        target_table = dataset + destination_table
+
+        pandas_gbq.to_gbq(
+            dataframe=table,
+            destination_table=target_table,
+            project_id="connection-123",
+            table_schema=table_schema,
+            credentials=credentials,
+            if_exists="replace"
+        )
+
+        return bytes_processed
+
+    else:
+        print('no production mode')

--- a/technical_indicators/bitcoin_fifty_week.py
+++ b/technical_indicators/bitcoin_fifty_week.py
@@ -37,19 +37,25 @@ def schema() -> list[dict]:
     ]
     return table_schema
 
-def run_etl(credentials, dataset: str) -> None:
-    current_week = current_week_func()
-    table = fetch_transactions(current_week)
-    table_schema = schema()
-    target_table = dataset + destination_table
+def run_etl(credentials, dataset: str, mode: str) -> None:
 
-    pandas_gbq.to_gbq(
-        dataframe=table,
-        destination_table=target_table,
-        project_id="connection-123",
-        table_schema=table_schema,
-        credentials=credentials,
-        if_exists="replace"
-    )
+    if mode == 'prod':
 
-    return 0
+        current_week = current_week_func()
+        table = fetch_transactions(current_week)
+        table_schema = schema()
+        target_table = dataset + destination_table
+
+        pandas_gbq.to_gbq(
+            dataframe=table,
+            destination_table=target_table,
+            project_id="connection-123",
+            table_schema=table_schema,
+            credentials=credentials,
+            if_exists="replace"
+        )
+
+        return 0
+
+    else:
+        print('no production mode')

--- a/technical_indicators/bitcoin_transactions_volume.py
+++ b/technical_indicators/bitcoin_transactions_volume.py
@@ -46,19 +46,24 @@ def schema() -> list[dict]:
     ]
     return table_schema
 
-def run_etl(credentials,dataset:str) -> None:
-    table, bytes_processed = fetch_transactions(credentials)
-    table_schema = schema()
-    target_table = dataset + destination_table
-    
-    pandas_gbq.to_gbq(
-        dataframe=table,
-        destination_table=target_table,
-        project_id="connection-123",
-        table_schema=table_schema,
-        credentials=credentials,
-        if_exists="replace" 
-    )
+def run_etl(credentials,dataset:str,mode:str) -> None:
 
-    return bytes_processed
+    if mode == 'prod':
 
+        table, bytes_processed = fetch_transactions(credentials)
+        table_schema = schema()
+        target_table = dataset + destination_table
+
+        pandas_gbq.to_gbq(
+            dataframe=table,
+            destination_table=target_table,
+            project_id="connection-123",
+            table_schema=table_schema,
+            credentials=credentials,
+            if_exists="replace"
+        )
+
+        return bytes_processed
+
+    else:
+        print('no production mode')

--- a/technical_indicators/bollinger_bands.py
+++ b/technical_indicators/bollinger_bands.py
@@ -64,18 +64,24 @@ def schema() -> list[dict]:
     ]
     return table_schema
 
-def run_etl(credentials, dataset: str) -> None:
-    table, bytes_processed = calculate_bollinger_bands(credentials)
-    table_schema = schema()
-    target_table = dataset + destination_table
+def run_etl(credentials, dataset: str, mode: str) -> None:
 
-    pandas_gbq.to_gbq(
-        dataframe=table,
-        destination_table=target_table,
-        project_id="connection-123",
-        table_schema=table_schema,
-        credentials=credentials,
-        if_exists="replace"
-    )
+    if mode == 'prod':
 
-    return bytes_processed
+        table, bytes_processed = calculate_bollinger_bands(credentials)
+        table_schema = schema()
+        target_table = dataset + destination_table
+
+        pandas_gbq.to_gbq(
+            dataframe=table,
+            destination_table=target_table,
+            project_id="connection-123",
+            table_schema=table_schema,
+            credentials=credentials,
+            if_exists="replace"
+        )
+
+        return bytes_processed
+
+    else:
+        print('no production mode')

--- a/technical_indicators/btc_moving_averages.py
+++ b/technical_indicators/btc_moving_averages.py
@@ -55,19 +55,24 @@ def schema() -> list[dict]:
     ]
     return table_schema
 
-def run_etl(credentials,dataset:str) -> None:
-   
-    table, bytes_processed = calculate_ma(credentials)
-    table_schema = schema()
-    target_table = dataset + destination_table
+def run_etl(credentials,dataset:str,mode:str) -> None:
 
-    pandas_gbq.to_gbq(
-        dataframe=table,
-        destination_table=target_table,
-        project_id="connection-123",
-        table_schema=table_schema,
-        credentials=credentials,
-        if_exists="replace" 
-    )
+    if mode == 'prod':
 
-    return bytes_processed
+        table, bytes_processed = calculate_ma(credentials)
+        table_schema = schema()
+        target_table = dataset + destination_table
+
+        pandas_gbq.to_gbq(
+            dataframe=table,
+            destination_table=target_table,
+            project_id="connection-123",
+            table_schema=table_schema,
+            credentials=credentials,
+            if_exists="replace"
+        )
+
+        return bytes_processed
+
+    else:
+        print('no production mode')

--- a/technical_indicators/cmc_data.py
+++ b/technical_indicators/cmc_data.py
@@ -77,30 +77,36 @@ def schema() -> list[dict]:
     ]
     return table_schema
 
-def run_etl(credentials,dataset:str) -> None:
-    project = "connection-123"
-    client = bigquery.Client(credentials=credentials, project=project)
-    table = fetch_cmc_data()
-    table_schema = schema()
+def run_etl(credentials,dataset:str,mode:str) -> None:
 
-    job_config = bigquery.LoadJobConfig(
-        schema=table_schema,
-        write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
-        time_partitioning=bigquery.TimePartitioning(
-            type_=bigquery.TimePartitioningType.DAY,
-            field="status_timestamp"
-        ),
-        destination_table_description="Global snapshot of CoinMarketCap aggregated metrics (market caps, 24h volumes, dominance and sector-specific caps) quoted in USD. One row per API response"
-    )
+    if mode == 'prod':
 
-    table_ref = dataset + destination_table
+        project = "connection-123"
+        client = bigquery.Client(credentials=credentials, project=project)
+        table = fetch_cmc_data()
+        table_schema = schema()
 
-    job = client.load_table_from_dataframe(
-        table,
-        table_ref,
-        job_config=job_config
-    )
+        job_config = bigquery.LoadJobConfig(
+            schema=table_schema,
+            write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
+            time_partitioning=bigquery.TimePartitioning(
+                type_=bigquery.TimePartitioningType.DAY,
+                field="status_timestamp"
+            ),
+            destination_table_description="Global snapshot of CoinMarketCap aggregated metrics (market caps, 24h volumes, dominance and sector-specific caps) quoted in USD. One row per API response"
+        )
 
-    job.result()
+        table_ref = dataset + destination_table
 
-    return 0
+        job = client.load_table_from_dataframe(
+            table,
+            table_ref,
+            job_config=job_config
+        )
+
+        job.result()
+
+        return 0
+
+    else:
+        print('no production mode')

--- a/technical_indicators/cpi_data.py
+++ b/technical_indicators/cpi_data.py
@@ -76,30 +76,36 @@ def schema() -> list[dict]:
     ]
     return table_schema
 
-def run_etl(credentials,dataset:str) -> None:
-    project = "connection-123"
-    client = bigquery.Client(credentials=credentials, project=project)
-    table = get_cpi_data()
-    table_schema = schema()
+def run_etl(credentials,dataset:str,mode:str) -> None:
 
-    job_config = bigquery.LoadJobConfig(
-        schema=table_schema,
-        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
-        time_partitioning=bigquery.TimePartitioning(
-            type_=bigquery.TimePartitioningType.DAY,
-            field="date"
-        ),
-        destination_table_description="CPI data monthly reading"
-    )
+    if mode == 'prod':
 
-    table_ref = dataset + destination_table
+        project = "connection-123"
+        client = bigquery.Client(credentials=credentials, project=project)
+        table = get_cpi_data()
+        table_schema = schema()
 
-    job = client.load_table_from_dataframe(
-        table,
-        table_ref,
-        job_config=job_config
-    )
+        job_config = bigquery.LoadJobConfig(
+            schema=table_schema,
+            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+            time_partitioning=bigquery.TimePartitioning(
+                type_=bigquery.TimePartitioningType.DAY,
+                field="date"
+            ),
+            destination_table_description="CPI data monthly reading"
+        )
 
-    job.result()
+        table_ref = dataset + destination_table
 
-    return 0
+        job = client.load_table_from_dataframe(
+            table,
+            table_ref,
+            job_config=job_config
+        )
+
+        job.result()
+
+        return 0
+
+    else:
+        print('no production mode')

--- a/technical_indicators/ethereum_closing_prices.py
+++ b/technical_indicators/ethereum_closing_prices.py
@@ -64,30 +64,36 @@ def schema() -> list[dict]:
     ]
     return table_schema
 
-def run_etl(credentials,dataset:str) -> None:
-    project = "connection-123"
-    client = bigquery.Client(credentials=credentials, project=project)
-    table = fetch_eth_price()
-    table_schema = schema()
+def run_etl(credentials,dataset:str,mode:str) -> None:
 
-    job_config = bigquery.LoadJobConfig(
-        schema=table_schema,
-        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
-        time_partitioning=bigquery.TimePartitioning(
-            type_=bigquery.TimePartitioningType.DAY,
-            field="timestamp"
-        ),
-        destination_table_description="Daily closing prices for ethereum"
-    )
+    if mode == 'prod':
 
-    table_ref = dataset + destination_table
+        project = "connection-123"
+        client = bigquery.Client(credentials=credentials, project=project)
+        table = fetch_eth_price()
+        table_schema = schema()
 
-    job = client.load_table_from_dataframe(
-        table,
-        table_ref,
-        job_config=job_config
-    )
+        job_config = bigquery.LoadJobConfig(
+            schema=table_schema,
+            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+            time_partitioning=bigquery.TimePartitioning(
+                type_=bigquery.TimePartitioningType.DAY,
+                field="timestamp"
+            ),
+            destination_table_description="Daily closing prices for ethereum"
+        )
 
-    job.result()
+        table_ref = dataset + destination_table
 
-    return 0
+        job = client.load_table_from_dataframe(
+            table,
+            table_ref,
+            job_config=job_config
+        )
+
+        job.result()
+
+        return 0
+
+    else:
+        print('no production mode')

--- a/technical_indicators/macd.py
+++ b/technical_indicators/macd.py
@@ -52,18 +52,24 @@ def schema() -> list[dict]:
     return table_schema
 
 
-def run_etl(credentials, dataset: str) -> None:
-    table,bytes_processed = calculate_macd(credentials)
-    table_schema = schema()
-    target_table = dataset + destination_table
+def run_etl(credentials, dataset: str, mode: str) -> None:
 
-    pandas_gbq.to_gbq(
-        dataframe=table,
-        destination_table=target_table,
-        project_id="connection-123",
-        table_schema=table_schema,
-        credentials=credentials,
-        if_exists="replace"
-    )
+    if mode == 'prod':
 
-    return bytes_processed
+        table,bytes_processed = calculate_macd(credentials)
+        table_schema = schema()
+        target_table = dataset + destination_table
+
+        pandas_gbq.to_gbq(
+            dataframe=table,
+            destination_table=target_table,
+            project_id="connection-123",
+            table_schema=table_schema,
+            credentials=credentials,
+            if_exists="replace"
+        )
+
+        return bytes_processed
+
+    else:
+        print('no production mode')

--- a/technical_indicators/mvrv_score.py
+++ b/technical_indicators/mvrv_score.py
@@ -1,4 +1,3 @@
-
 import pandas as pd
 import requests
 import pandas_gbq
@@ -52,30 +51,36 @@ def schema() -> list[dict]:
 
     return table_schema
 
-def run_etl(credentials,dataset:str) -> None:
-    project = "connection-123"
-    client = bigquery.Client(credentials=credentials, project=project)
-    table = fetch_mvrv()
-    table_schema = schema()
+def run_etl(credentials,dataset:str,mode:str) -> None:
 
-    job_config = bigquery.LoadJobConfig(
-        schema=table_schema,
-        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
-        time_partitioning=bigquery.TimePartitioning(
-            type_=bigquery.TimePartitioningType.DAY,
-            field="time"
-        ),
-        destination_table_description="Daily value for the mvrv score"
-    )
+    if mode == 'prod':
 
-    table_ref = dataset + destination_table
+        project = "connection-123"
+        client = bigquery.Client(credentials=credentials, project=project)
+        table = fetch_mvrv()
+        table_schema = schema()
 
-    job = client.load_table_from_dataframe(
-        table,
-        table_ref,
-        job_config=job_config
-    )
+        job_config = bigquery.LoadJobConfig(
+            schema=table_schema,
+            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+            time_partitioning=bigquery.TimePartitioning(
+                type_=bigquery.TimePartitioningType.DAY,
+                field="time"
+            ),
+            destination_table_description="Daily value for the mvrv score"
+        )
 
-    job.result()
+        table_ref = dataset + destination_table
 
-    return 0
+        job = client.load_table_from_dataframe(
+            table,
+            table_ref,
+            job_config=job_config
+        )
+
+        job.result()
+
+        return 0
+
+    else:
+        print('no production mode')

--- a/technical_indicators/others_dominance.py
+++ b/technical_indicators/others_dominance.py
@@ -1,4 +1,3 @@
-
 import pandas as pd
 import pandas_gbq
 from google.cloud import bigquery
@@ -43,18 +42,24 @@ def schema() -> list[dict]:
     ]
     return table_schema
 
-def run_etl(credentials, dataset: str) -> None:
-    table, bytes_processed = fetch_data(credentials)
-    table_schema = schema()
-    target_table = dataset + destination_table
+def run_etl(credentials, dataset: str, mode: str) -> None:
 
-    pandas_gbq.to_gbq(
-        dataframe=table,
-        destination_table=target_table,
-        project_id="connection-123",
-        table_schema=table_schema,
-        credentials=credentials,
-        if_exists="replace"
-    )
+    if mode == 'prod':
 
-    return bytes_processed
+        table, bytes_processed = fetch_data(credentials)
+        table_schema = schema()
+        target_table = dataset + destination_table
+
+        pandas_gbq.to_gbq(
+            dataframe=table,
+            destination_table=target_table,
+            project_id="connection-123",
+            table_schema=table_schema,
+            credentials=credentials,
+            if_exists="replace"
+        )
+
+        return bytes_processed
+
+    else:
+        print('no production mode')

--- a/technical_indicators/rsi.py
+++ b/technical_indicators/rsi.py
@@ -58,18 +58,24 @@ def schema() -> list[dict]:
     ]
     return table_schema
 
-def run_etl(credentials, dataset: str) -> None:
-    table,bytes_processed = calculate_rsi(credentials)
-    table_schema = schema()
-    target_table = dataset + destination_table
+def run_etl(credentials, dataset: str, mode: str) -> None:
 
-    pandas_gbq.to_gbq(
-        dataframe=table,
-        destination_table=target_table,
-        project_id="connection-123",
-        table_schema=table_schema,
-        credentials=credentials,
-        if_exists="replace"
-    )
+    if mode == 'prod':
 
-    return bytes_processed
+        table, bytes_processed = calculate_rsi(credentials)
+        table_schema = schema()
+        target_table = dataset + destination_table
+
+        pandas_gbq.to_gbq(
+            dataframe=table,
+            destination_table=target_table,
+            project_id="connection-123",
+            table_schema=table_schema,
+            credentials=credentials,
+            if_exists="replace"
+        )
+
+        return bytes_processed
+
+    else:
+        print('no production mode')

--- a/technical_indicators/tether_data.py
+++ b/technical_indicators/tether_data.py
@@ -58,30 +58,36 @@ def schema() -> list[dict]:
     return table_schema
 
 
-def run_etl(credentials,dataset:str) -> None:
-    project = "connection-123"
-    client = bigquery.Client(credentials=credentials, project=project)
-    table = fetch_tether_data()
-    table_schema = schema()
+def run_etl(credentials,dataset:str,mode:str) -> None:
 
-    job_config = bigquery.LoadJobConfig(
-        schema=table_schema,
-        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
-        time_partitioning=bigquery.TimePartitioning(
-            type_=bigquery.TimePartitioningType.DAY,
-            field="timestamp"
-        ),
-        destination_table_description="market cap and daily volume for usdt"
-    )
+    if mode == 'prod':
 
-    table_ref = dataset + destination_table
+        project = "connection-123"
+        client = bigquery.Client(credentials=credentials, project=project)
+        table = fetch_tether_data()
+        table_schema = schema()
 
-    job = client.load_table_from_dataframe(
-        table,
-        table_ref,
-        job_config=job_config
-    )
+        job_config = bigquery.LoadJobConfig(
+            schema=table_schema,
+            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+            time_partitioning=bigquery.TimePartitioning(
+                type_=bigquery.TimePartitioningType.DAY,
+                field="timestamp"
+            ),
+            destination_table_description="market cap and daily volume for usdt"
+        )
 
-    job.result()
+        table_ref = dataset + destination_table
 
-    return 0
+        job = client.load_table_from_dataframe(
+            table,
+            table_ref,
+            job_config=job_config
+        )
+
+        job.result()
+
+        return 0
+
+    else:
+        print('no production mode')

--- a/technical_indicators/total_three_divided_btc.py
+++ b/technical_indicators/total_three_divided_btc.py
@@ -47,19 +47,24 @@ def schema() -> list[dict]:
     return table_schema
 
 
-def run_etl(credentials, dataset: str) -> None:
-    table,bytes_processed = fetch_transactions(credentials)
-    table_schema = schema()
-    target_table = dataset + destination_table
+def run_etl(credentials, dataset: str, mode: str) -> None:
 
-    pandas_gbq.to_gbq(
-        dataframe=table,
-        destination_table=target_table,
-        project_id="connection-123",
-        table_schema=table_schema,
-        credentials=credentials,
-        if_exists="replace"
-    )
+    if mode == 'prod':
 
-    return bytes_processed
+        table,bytes_processed = fetch_transactions(credentials)
+        table_schema = schema()
+        target_table = dataset + destination_table
 
+        pandas_gbq.to_gbq(
+            dataframe=table,
+            destination_table=target_table,
+            project_id="connection-123",
+            table_schema=table_schema,
+            credentials=credentials,
+            if_exists="replace"
+        )
+
+        return bytes_processed
+
+    else:
+        print('no production mode')


### PR DESCRIPTION
This pull request introduces a runtime mode switch to the ETL pipeline, allowing jobs to distinguish between local and production environments. The main change is the addition of a `mode` parameter, which is determined at runtime and passed to all ETL job functions. Each job now checks this mode and only performs production operations if running in production; otherwise, it prints a message and skips execution. This improves safety and flexibility for local development and testing.

**Runtime environment detection and propagation:**

* Added `is_running_locally()` in `main.py` to detect local vs. production execution, and passed the resulting `mode` to each ETL job. (`[[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R5)`, `[[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R60-R71)`, `[[3]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L89-R98)`)

**ETL job interface update:**

* Updated all ETL job functions in technical indicators modules to accept a new `mode` parameter and conditionally run production logic only if `mode == 'prod'`. (`[[1]](diffhunk://#diff-be76f120f82a23eab3fed0e5399c508bf2516d32dbe7aaa2502d365e47286f18L66-R68)`, `[[2]](diffhunk://#diff-a63dbcb6ffb90f762bf686336b5600d9bdcdad825366995c005ce99c2d9b0008L58-R60)`, `[[3]](diffhunk://#diff-6bd045320febd7e8fae56f877901a51b596d684503ea31ebab6bab87040de748L40-R43)`, `[[4]](diffhunk://#diff-afb318e6a166aea78cfa728f7dffb77d47627ef75d2cd7f9102af922fcf008caL49-R52)`, `[[5]](diffhunk://#diff-4aaccc5dd96f0047d17f2071ebc48e91f8d3e72849e500d2eed5d7c9d9fd097dL67-R70)`, `[[6]](diffhunk://#diff-631b284461e8e27e9eec465991718ee97da9e91fd3d44f854c1b679b0786f604L58-R60)`, `[[7]](diffhunk://#diff-373f312fa427f10657adceabab7333b4f0885c8e412261a90df87a14572c4094L80-R83)`, `[[8]](diffhunk://#diff-532ad61597171dadd8b16b99d101356831307603be2c9ae963d646420d9811c9L79-R82)`, `[[9]](diffhunk://#diff-0cda6361e5080b8c8351c31a718d87e426ac30cc1c9b5ce5910b2bbc262ae826L67-R70)`, `[[10]](diffhunk://#diff-8ea8b75f76cedcea57c2c62d67a56d202ed55526feef8b637f0133f865ece884L55-R58)`, `[[11]](diffhunk://#diff-8ef163cd50480aa1c21085a537ad577dc753d150bafe8a44992360de19c27299L55-R57)`, `[[12]](diffhunk://#diff-786da35d6c9ee2ec1aa6f3669eed86c18a538e4c3fcecae0fd00d4a3e4dcd91cL46-R48)`, `[[13]](diffhunk://#diff-e39e0dae404642a615d3ebe00f41572d4447bbae2780c1b16405306c3213cebdL61-R64)`, `[[14]](diffhunk://#diff-94dc92331cd00c68108b577d2db195bd9ff4bcadf1c551dc1e2d45fe4ebcd7e2L61-R64)`, `[[15]](diffhunk://#diff-3335e8b7e107e7cfa340e519fbc86fbe3064cc911349786a5268e3d2fced3d16L50-R53)`)

**Local mode handling:**

* In each ETL job, added an `else` branch that prints a message ("no production mode") and skips execution when not in production mode. (`[[1]](diffhunk://#diff-be76f120f82a23eab3fed0e5399c508bf2516d32dbe7aaa2502d365e47286f18R84-R86)`, `[[2]](diffhunk://#diff-a63dbcb6ffb90f762bf686336b5600d9bdcdad825366995c005ce99c2d9b0008R76-R78)`, `[[3]](diffhunk://#diff-6bd045320febd7e8fae56f877901a51b596d684503ea31ebab6bab87040de748R59-R61)`, `[[4]](diffhunk://#diff-afb318e6a166aea78cfa728f7dffb77d47627ef75d2cd7f9102af922fcf008caR68-R69)`, `[[5]](diffhunk://#diff-4aaccc5dd96f0047d17f2071ebc48e91f8d3e72849e500d2eed5d7c9d9fd097dR85-R87)`, `[[6]](diffhunk://#diff-631b284461e8e27e9eec465991718ee97da9e91fd3d44f854c1b679b0786f604R76-R78)`, `[[7]](diffhunk://#diff-373f312fa427f10657adceabab7333b4f0885c8e412261a90df87a14572c4094R110-R112)`, `[[8]](diffhunk://#diff-532ad61597171dadd8b16b99d101356831307603be2c9ae963d646420d9811c9R109-R111)`, `[[9]](diffhunk://#diff-0cda6361e5080b8c8351c31a718d87e426ac30cc1c9b5ce5910b2bbc262ae826R97-R99)`, `[[10]](diffhunk://#diff-8ea8b75f76cedcea57c2c62d67a56d202ed55526feef8b637f0133f865ece884R73-R75)`, `[[11]](diffhunk://#diff-8ef163cd50480aa1c21085a537ad577dc753d150bafe8a44992360de19c27299R84-R86)`, `[[12]](diffhunk://#diff-786da35d6c9ee2ec1aa6f3669eed86c18a538e4c3fcecae0fd00d4a3e4dcd91cR63-R65)`, `[[13]](diffhunk://#diff-e39e0dae404642a615d3ebe00f41572d4447bbae2780c1b16405306c3213cebdR79-R81)`, `[[14]](diffhunk://#diff-94dc92331cd00c68108b577d2db195bd9ff4bcadf1c551dc1e2d45fe4ebcd7e2R91-R93)`, `[[15]](diffhunk://#diff-3335e8b7e107e7cfa340e519fbc86fbe3064cc911349786a5268e3d2fced3d16R69-R70)`)

**Minor cleanups:**

* Removed unnecessary blank lines at the top of `technical_indicators/mvrv_score.py` and `technical_indicators/others_dominance.py`. (`[[1]](diffhunk://#diff-8ef163cd50480aa1c21085a537ad577dc753d150bafe8a44992360de19c27299L1)`, `[[2]](diffhunk://#diff-786da35d6c9ee2ec1aa6f3669eed86c18a538e4c3fcecae0fd00d4a3e4dcd91cL1)`)

These changes collectively make the ETL pipeline safer for local development and testing by preventing accidental production operations outside the intended environment.