### PR TITLE
added staging

### DIFF
--- a/technical_indicators/bitcoin_closing_prices.py
+++ b/technical_indicators/bitcoin_closing_prices.py
@@ -1,11 +1,13 @@
 import pandas as pd
 import requests
 import pandas_gbq
-from google.cloud import bigquery
-from typing import Any
 import os
 import logging
-from google.oauth2 import service_account
+from pathlib import Path
+
+current_dir = Path(__file__).parent
+local_folder = current_dir.parent / "testing_area"
+local_folder_string = str(local_folder.resolve())
 
 destination_table = "bitcoin_price"
 
@@ -83,4 +85,9 @@ def run_etl(credentials,dataset:str,mode:str) -> None:
         return 0
 
     else:
-        print('no production mode')
+        print('test mode')
+        table = fetch_bitcoin_price()
+        csv_filename = os.path.join(local_folder_string, "bitcoin_closing_prices_local.csv")
+        table.to_csv(csv_filename, index=False)
+        print(f'Data saved to {csv_filename}')
+        return 0

--- a/technical_indicators/bitcoin_ema.py
+++ b/technical_indicators/bitcoin_ema.py
@@ -1,10 +1,14 @@
 import pandas as pd
 import pandas_gbq
 from google.cloud import bigquery
-from typing import Any
-from google.oauth2 import service_account
 import logging
-from datetime import datetime, timedelta
+import os
+from pathlib import Path
+
+current_dir = Path(__file__).parent
+local_folder = current_dir.parent / "testing_area"
+local_folder_string = str(local_folder.resolve())
+
 
 destination_table = "btc_ema"
 
@@ -75,4 +79,9 @@ def run_etl(credentials,dataset:str,mode:str) -> None:
         return bytes_processed
 
     else:
-        print('no production mode')
+        print('test mode')
+        table,bytes_processed = calculate_ema(credentials,periods=[9,12, 26, 20, 50, 200])
+        csv_filename = os.path.join(local_folder,"bitcoin_ema_local.csv")
+        table.to_csv(csv_filename, index=False)
+        print(f'Data saved to {csv_filename}')
+        return bytes_processed

--- a/technical_indicators/bitcoin_fifty_week.py
+++ b/technical_indicators/bitcoin_fifty_week.py
@@ -3,6 +3,13 @@ import pandas as pd
 import functools
 from datetime import datetime
 import pandas_gbq
+from pathlib import Path
+import os
+
+current_dir = Path(__file__).parent
+local_folder = current_dir.parent / "testing_area"
+local_folder_string = str(local_folder.resolve())
+
 
 destination_table = "bitcoin_fifty_week"
 
@@ -58,4 +65,10 @@ def run_etl(credentials, dataset: str, mode: str) -> None:
         return 0
 
     else:
-        print('no production mode')
+        print('test mode')
+        current_week = current_week_func()
+        table = fetch_transactions(current_week)
+        csv_filename = os.path.join(local_folder,"bitcoin_closing_prices_local.csv")
+        table.to_csv(csv_filename, index=False)
+        print(f'Data saved to {csv_filename}')
+        return 0


### PR DESCRIPTION
This pull request updates the ETL scripts for Bitcoin technical indicators to improve local testing support. The main changes add functionality for saving test-mode results to CSV files in a dedicated `testing_area` folder, and refactor path handling for better portability. 

**Local Testing Enhancements:**

* Added logic to save test-mode output as CSV files in a `testing_area` directory for `bitcoin_closing_prices.py`, `bitcoin_ema.py`, and `bitcoin_fifty_week.py`, making it easier to inspect results locally. [[1]](diffhunk://#diff-be76f120f82a23eab3fed0e5399c508bf2516d32dbe7aaa2502d365e47286f18L86-R93) [[2]](diffhunk://#diff-a63dbcb6ffb90f762bf686336b5600d9bdcdad825366995c005ce99c2d9b0008L78-R87) [[3]](diffhunk://#diff-6bd045320febd7e8fae56f877901a51b596d684503ea31ebab6bab87040de748L61-R74)
* Changed the test-mode print statement from 'no production mode' to 'test mode' for clarity in all affected scripts. [[1]](diffhunk://#diff-be76f120f82a23eab3fed0e5399c508bf2516d32dbe7aaa2502d365e47286f18L86-R93) [[2]](diffhunk://#diff-a63dbcb6ffb90f762bf686336b5600d9bdcdad825366995c005ce99c2d9b0008L78-R87) [[3]](diffhunk://#diff-6bd045320febd7e8fae56f877901a51b596d684503ea31ebab6bab87040de748L61-R74)

**Path and Imports Refactoring:**

* Introduced `pathlib.Path` for handling file and folder paths, improving code portability and readability in all three scripts. [[1]](diffhunk://#diff-be76f120f82a23eab3fed0e5399c508bf2516d32dbe7aaa2502d365e47286f18L4-R10) [[2]](diffhunk://#diff-a63dbcb6ffb90f762bf686336b5600d9bdcdad825366995c005ce99c2d9b0008L4-R11) [[3]](diffhunk://#diff-6bd045320febd7e8fae56f877901a51b596d684503ea31ebab6bab87040de748R6-R12)
* Removed unused imports (`Any`, `service_account`, etc.) for cleaner code. [[1]](diffhunk://#diff-be76f120f82a23eab3fed0e5399c508bf2516d32dbe7aaa2502d365e47286f18L4-R10) [[2]](diffhunk://#diff-a63dbcb6ffb90f762bf686336b5600d9bdcdad825366995c005ce99c2d9b0008L4-R11)

These changes make local development and testing more straightforward and help keep the codebase tidy.