### PR TITLE
added the fear and greed

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from typing import Any
 import time
 import os
 
+from technical_indicators.fear_greed import fetch_fear_greed_index
 
 logging.basicConfig(
     filename='logfile.txt',  
@@ -28,7 +29,8 @@ from technical_indicators import (
     cmc_data,
     mvrv_score,
     others_dominance,
-    total_three_divided_btc
+    total_three_divided_btc,
+    fear_greed
     )
 
 
@@ -82,7 +84,8 @@ def main() -> None:
         cmc_data,
         mvrv_score,
         others_dominance,
-        total_three_divided_btc
+        total_three_divided_btc,
+        fear_greed
     ]
 
     total_bytes_processed = 0

--- a/pages/13_fear_greed.py
+++ b/pages/13_fear_greed.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.title("Fetch Fear and Greed index")

--- a/pages/1_calculate_bollinger_bands.py
+++ b/pages/1_calculate_bollinger_bands.py
@@ -26,58 +26,61 @@ for dirpath, dirnames, filenames in walk(data_path_str):
     if matching_data_file:
         break
 
-@st.cache_data(ttl=3600)
+@st.cache_data
 def load_data(matching_data_file):
     df = pd.read_csv(matching_data_file)
     return df
 
+def streamlit_page():
+    st.title("Calculate bollinger bands")
 
-st.title("Calculate bollinger bands")
+    df = load_data(matching_data_file)
 
-df = load_data(matching_data_file)
+    # Only plot if required columns exist
+    required_columns = ['price', 'upper_band', 'middle_band', 'lower_band']
+    missing_columns = [col for col in required_columns if col not in df.columns]
 
-# Only plot if required columns exist
-required_columns = ['price', 'upper_band', 'middle_band', 'lower_band']
-missing_columns = [col for col in required_columns if col not in df.columns]
-
-if missing_columns:
-    st.error(f"Missing required columns: {missing_columns}")
-    st.info("Please ensure your data.csv contains: price, upper_band, middle_band, lower_band")
-else:
-    # Create subplots
-    fig = make_subplots(
-        rows=3, cols=1,
-        shared_xaxes=True,
-        vertical_spacing=0.05,
-        subplot_titles=('Bollinger Bands', 'BB Width', '%B'),
-        row_heights=[0.5, 0.25, 0.25]
-    )
-
-    # Try using index if date is not a column
-    if 'date' not in df.columns:
-        x_data = df.index
+    if missing_columns:
+        st.error(f"Missing required columns: {missing_columns}")
+        st.info("Please ensure your data.csv contains: price, upper_band, middle_band, lower_band")
     else:
-        x_data = df['date']
+        # Create subplots
+        fig = make_subplots(
+            rows=3, cols=1,
+            shared_xaxes=True,
+            vertical_spacing=0.05,
+            subplot_titles=('Bollinger Bands', 'BB Width', '%B'),
+            row_heights=[0.5, 0.25, 0.25]
+        )
 
-    # Bollinger Bands
-    fig.add_trace(go.Scatter(x=x_data, y=df['price'], name='Price', line=dict(color='blue')), row=1, col=1)
-    fig.add_trace(go.Scatter(x=x_data, y=df['upper_band'], name='Upper Band', line=dict(color='red', dash='dash')), row=1, col=1)
-    fig.add_trace(go.Scatter(x=x_data, y=df['middle_band'], name='Middle Band', line=dict(color='gray', dash='dash')), row=1, col=1)
-    fig.add_trace(go.Scatter(x=x_data, y=df['lower_band'], name='Lower Band', line=dict(color='green', dash='dash')), row=1, col=1)
+        # Try using index if date is not a column
+        if 'date' not in df.columns:
+            x_data = df.index
+        else:
+            x_data = df['date']
 
-    # BB Width
-    if 'bb_width' in df.columns:
-        fig.add_trace(go.Scatter(x=x_data, y=df['bb_width'], name='BB Width', line=dict(color='purple')), row=2, col=1)
+        # Bollinger Bands
+        fig.add_trace(go.Scatter(x=x_data, y=df['price'], name='Price', line=dict(color='blue')), row=1, col=1)
+        fig.add_trace(go.Scatter(x=x_data, y=df['upper_band'], name='Upper Band', line=dict(color='red', dash='dash')), row=1, col=1)
+        fig.add_trace(go.Scatter(x=x_data, y=df['middle_band'], name='Middle Band', line=dict(color='gray', dash='dash')), row=1, col=1)
+        fig.add_trace(go.Scatter(x=x_data, y=df['lower_band'], name='Lower Band', line=dict(color='green', dash='dash')), row=1, col=1)
 
-    # %B
-    if 'percent_b' in df.columns:
-        fig.add_trace(go.Scatter(x=x_data, y=df['percent_b'], name='%B', line=dict(color='orange')), row=3, col=1)
-        # Add reference lines at 0, 0.5, and 1
-        fig.add_hline(y=0, line_dash="dot", line_color="gray", row=3, col=1)
-        fig.add_hline(y=0.5, line_dash="dot", line_color="gray", row=3, col=1)
-        fig.add_hline(y=1, line_dash="dot", line_color="gray", row=3, col=1)
+        # BB Width
+        if 'bb_width' in df.columns:
+            fig.add_trace(go.Scatter(x=x_data, y=df['bb_width'], name='BB Width', line=dict(color='purple')), row=2, col=1)
 
-    fig.update_layout(height=800, showlegend=True)
-    st.plotly_chart(fig, use_container_width=True)
+        # %B
+        if 'percent_b' in df.columns:
+            fig.add_trace(go.Scatter(x=x_data, y=df['percent_b'], name='%B', line=dict(color='orange')), row=3, col=1)
+            # Add reference lines at 0, 0.5, and 1
+            fig.add_hline(y=0, line_dash="dot", line_color="gray", row=3, col=1)
+            fig.add_hline(y=0.5, line_dash="dot", line_color="gray", row=3, col=1)
+            fig.add_hline(y=1, line_dash="dot", line_color="gray", row=3, col=1)
 
-st.dataframe(df)
+        fig.update_layout(height=800, showlegend=True)
+        st.plotly_chart(fig, use_container_width=True)
+
+    st.dataframe(df)
+
+if __name__ == '__main__':
+    streamlit_page()

--- a/technical_indicators/fear_greed.py
+++ b/technical_indicators/fear_greed.py
@@ -1,0 +1,86 @@
+import pandas as pd
+import requests
+import pandas_gbq
+import os
+import logging
+from pathlib import Path
+current_dir = Path(__file__).parent
+local_folder = current_dir / "testing_area"
+local_folder_string = str(local_folder.resolve())
+
+destination_table = "fear_greed"
+
+logger = logging.getLogger(__name__)
+
+def fetch_fear_greed_index(limit=365):
+    url = f"https://api.alternative.me/fng/?limit={limit}&format=json"
+    response = requests.get(url)
+    response.raise_for_status()
+
+    data = response.json()
+
+        # Convert to DataFrame
+    df = pd.DataFrame(data['data'])
+
+        # Convert timestamp to datetime
+    df['timestamp'] = pd.to_datetime(df['timestamp'].astype(int), unit='s').dt.date
+    df['value'] = df['value'].astype(int)
+
+    classification_map = {
+            'Extreme Fear': 1,
+            'Fear': 2,
+            'Neutral': 3,
+            'Greed': 4,
+            'Extreme Greed': 5
+        }
+
+    df['numeric_sentiment'] = df['value_classification'].map(classification_map)
+
+        # Sort by date (newest first)
+    df = df.sort_values('timestamp', ascending=False)
+
+    return df[['value_classification','numeric_sentiment', 'timestamp']]
+
+def schema() -> list[dict]:
+    """
+    create the schema for the bq table
+    """
+    table_schema = [
+        {'name': 'value_classification', 'type': 'string', 'description': 'the categorical classification of the index'},
+        {'name': 'numeric_sentiment', 'type': 'INT64', 'description': 'the numerical sentiment of the index'},
+        {'name': 'timestamp', 'type': 'DATE', 'description': 'the date of the index reading'}
+    ]
+    return table_schema
+
+def run_etl(credentials,dataset:str,mode:str) -> int:
+
+    if mode == 'prod':
+
+        table = fetch_fear_greed_index()
+        table_schema = schema()
+        target_table = dataset + destination_table
+
+        pandas_gbq.to_gbq(
+            dataframe=table,
+            destination_table=target_table,
+            project_id="connection-123",
+            table_schema=table_schema,
+            credentials=credentials,
+            if_exists="replace"
+        )
+
+        return 0
+
+    else:
+        print('test mode')
+        table = fetch_fear_greed_index()
+
+        # Create subdirectory if it doesn't exist
+        subdir = local_folder / fetch_fear_greed_index.__name__
+        subdir.mkdir(parents=True, exist_ok=True)
+
+        csv_filename = os.path.join(str(subdir), "data.csv")
+        table.to_csv(csv_filename, index=False)
+        print(f'Data saved to {csv_filename}')
+
+        return 0


### PR DESCRIPTION
This pull request introduces support for fetching and processing the Fear and Greed index as a new technical indicator, along with improvements to the Streamlit pages for usability and structure. The most significant changes include the addition of the `fetch_fear_greed_index` function, updates to the main pipeline to handle the new indicator, and new or improved Streamlit pages.

### Technical Indicator Integration

* Added new module `technical_indicators/fear_greed.py` with the `fetch_fear_greed_index` function, schema definition, and ETL logic for both production and test modes. This fetches the Fear and Greed index from an external API, processes the data, and supports saving to BigQuery or local CSV.
* Imported the `fetch_fear_greed_index` function in `main.py` to enable usage within the main pipeline.

### Pipeline Updates

* Updated the main pipeline in `main.py` to include `fear_greed` as part of the data processing and aggregation steps, ensuring the new indicator is handled alongside existing metrics. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L31-R33) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L85-R88)

### Streamlit Page Improvements

* Added a new Streamlit page `pages/13_fear_greed.py` to display and fetch the Fear and Greed index, enhancing the user interface for this metric.
* Improved the structure of `pages/1_calculate_bollinger_bands.py` by encapsulating the page logic in a `streamlit_page` function and adding an entry point for standalone execution. Also removed the `ttl` argument from the `@st.cache_data` decorator for simplicity. [[1]](diffhunk://#diff-02b0b01802b54cc3c729dddedc0ae0b3d682a9ac33bdad3436c974727ac35b39L29-R34) [[2]](diffhunk://#diff-02b0b01802b54cc3c729dddedc0ae0b3d682a9ac33bdad3436c974727ac35b39R84-R86)