### PR TITLE
Ma test

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,8 +4,6 @@ from typing import Any
 import time
 import os
 
-from technical_indicators.fear_greed import fetch_fear_greed_index
-
 logging.basicConfig(
     filename='logfile.txt',  
     level=logging.INFO, 

--- a/pages/1_calculate_bollinger_bands.py
+++ b/pages/1_calculate_bollinger_bands.py
@@ -39,6 +39,10 @@ def streamlit_page():
         st.write("No data found")
 
     else:
+
+        period = st.slider("Select Period (days)", min_value=10, max_value=len(df), value=100, step=10)
+        df_filtered = df.tail(period)
+
         # Create subplots
         fig = make_subplots(
             rows=3, cols=1,
@@ -50,23 +54,23 @@ def streamlit_page():
 
         # Try using index if date is not a column
         if 'date' not in df.columns:
-            x_data = df.index
+            x_data = df_filtered.index
         else:
-            x_data = df['date']
+            x_data = df_filtered['date']
 
         # Bollinger Bands
-        fig.add_trace(go.Scatter(x=x_data, y=df['price'], name='Price', line=dict(color='blue')), row=1, col=1)
-        fig.add_trace(go.Scatter(x=x_data, y=df['upper_band'], name='Upper Band', line=dict(color='red', dash='dash')), row=1, col=1)
-        fig.add_trace(go.Scatter(x=x_data, y=df['middle_band'], name='Middle Band', line=dict(color='gray', dash='dash')), row=1, col=1)
-        fig.add_trace(go.Scatter(x=x_data, y=df['lower_band'], name='Lower Band', line=dict(color='green', dash='dash')), row=1, col=1)
+        fig.add_trace(go.Scatter(x=x_data, y=df_filtered['price'], name='Price', line=dict(color='blue')), row=1, col=1)
+        fig.add_trace(go.Scatter(x=x_data, y=df_filtered['upper_band'], name='Upper Band', line=dict(color='red', dash='dash')), row=1, col=1)
+        fig.add_trace(go.Scatter(x=x_data, y=df_filtered['middle_band'], name='Middle Band', line=dict(color='gray', dash='dash')), row=1, col=1)
+        fig.add_trace(go.Scatter(x=x_data, y=df_filtered['lower_band'], name='Lower Band', line=dict(color='green', dash='dash')), row=1, col=1)
 
         # BB Width
         if 'bb_width' in df.columns:
-            fig.add_trace(go.Scatter(x=x_data, y=df['bb_width'], name='BB Width', line=dict(color='purple')), row=2, col=1)
+            fig.add_trace(go.Scatter(x=x_data, y=df_filtered['bb_width'], name='BB Width', line=dict(color='purple')), row=2, col=1)
 
         # %B
         if 'percent_b' in df.columns:
-            fig.add_trace(go.Scatter(x=x_data, y=df['percent_b'], name='%B', line=dict(color='orange')), row=3, col=1)
+            fig.add_trace(go.Scatter(x=x_data, y=df_filtered['percent_b'], name='%B', line=dict(color='orange')), row=3, col=1)
             # Add reference lines at 0, 0.5, and 1
             fig.add_hline(y=0, line_dash="dot", line_color="gray", row=3, col=1)
             fig.add_hline(y=0.5, line_dash="dot", line_color="gray", row=3, col=1)

--- a/pages/2_calculate_ema.py
+++ b/pages/2_calculate_ema.py
@@ -31,10 +31,9 @@ def load_data(matching_data_file):
     return df
 
 def streamlit_page():
-    st.title("Calculate EMA")
+    st.title("Bitcoin closing price and EMA")
 
     data = load_data(matching_data_file)
-    st.write(data.columns)
 
     fig = go.Figure()
 

--- a/pages/3_calculate_ma.py
+++ b/pages/3_calculate_ma.py
@@ -32,4 +32,48 @@ def load_data(matching_data_file):
     return df
 
 
-st.title("Calculate MA")
+def streamlit_page():
+    st.title("Bitcoin closing price and MA")
+
+    data = load_data(matching_data_file)
+
+    fig = go.Figure()
+
+    fig.add_trace(go.Scatter(
+        x=data['date_'],
+        y=data['price'],
+        mode='lines',
+        name='Price',
+        line=dict(color='blue', width=2)
+    ))
+    fig.add_trace(go.Scatter(
+        x=data['date_'],
+        y=data['sma_10'],
+        mode='lines',
+        name='MA 10',
+        line=dict(color='red', width=1, dash='dash')
+    ))
+    fig.add_trace(go.Scatter(
+        x=data['date_'],
+        y=data['sma_20'],
+        mode='lines',
+        name='MA 20',
+        line=dict(color='green', width=1, dash='dash')
+    ))
+    fig.add_trace(go.Scatter(
+        x=data['date_'],
+        y=data['sma_50'],
+        mode='lines',
+        name='MA 50',
+        line=dict(color='gray', width=1, dash='dash')
+    ))
+
+    st.plotly_chart(fig)
+
+    st.write("most recent data")
+
+    st.dataframe(data.head())
+
+if __name__ == "__main__":
+    streamlit_page()
+


### PR DESCRIPTION
This pull request introduces several improvements to the Streamlit pages for technical indicator visualization, focusing on better user interaction and consistent presentation. The main updates include adding period selection for Bollinger Bands, refactoring the moving average (MA) and exponential moving average (EMA) pages for clarity, and ensuring filtered data is used throughout the plots.

**User interaction improvements:**

* Added a period selection slider to the Bollinger Bands page, allowing users to choose the number of days displayed in the chart, and updated all relevant plots to use the filtered data based on this selection. [[1]](diffhunk://#diff-02b0b01802b54cc3c729dddedc0ae0b3d682a9ac33bdad3436c974727ac35b39R42-R45) [[2]](diffhunk://#diff-02b0b01802b54cc3c729dddedc0ae0b3d682a9ac33bdad3436c974727ac35b39L53-R73)

**Refactoring and consistency:**

* Refactored the Moving Average (MA) page (`pages/3_calculate_ma.py`) to define a `streamlit_page()` function, updated the title for clarity, and added a Plotly chart displaying price and multiple moving averages, along with a preview of the most recent data.
* Updated the Exponential Moving Average (EMA) page (`pages/2_calculate_ema.py`) to use a clearer title and removed extraneous debugging output.

**Code cleanup:**

* Removed an unused import (`fetch_fear_greed_index`) from `main.py`.